### PR TITLE
Fix: Use correct port for OAuth callback server

### DIFF
--- a/qt_worklog/services/auth/callback_server.py
+++ b/qt_worklog/services/auth/callback_server.py
@@ -4,6 +4,13 @@ from urllib.parse import urlparse, parse_qs
 
 from PySide6.QtCore import QObject, Signal
 
+from ... import config
+
+
+def get_redirect_port():
+    redirect_uri = config.GOOGLE_OAUTH_CLIENT_CONFIG["installed"]["redirect_uris"][0]
+    return urlparse(redirect_uri).port
+
 
 class CallbackHandler(BaseHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
@@ -26,9 +33,9 @@ class CallbackHandler(BaseHTTPRequestHandler):
 class CallbackServer(QObject):
     authorization_code_received = Signal(str)
 
-    def __init__(self, port=8080):
+    def __init__(self):
         super().__init__()
-        self.port = port
+        self.port = get_redirect_port()
         self.server = None
         self.thread = None
 


### PR DESCRIPTION
The callback server was hardcoded to use port 8080, which caused a "connection refused" error when the redirect URI in the Google OAuth client configuration used a different port.

This commit fixes the issue by dynamically parsing the port from the redirect URI and using it to start the callback server. This ensures that the server is listening on the correct port and can handle the redirect from Google.