### PR TITLE
Fix: Handle None port in redirect URI

### DIFF
--- a/qt_worklog/services/auth/callback_server.py
+++ b/qt_worklog/services/auth/callback_server.py
@@ -9,7 +9,13 @@ from ... import config
 
 def get_redirect_port():
     redirect_uri = config.GOOGLE_OAUTH_CLIENT_CONFIG["installed"]["redirect_uris"][0]
-    return urlparse(redirect_uri).port
+    parsed_uri = urlparse(redirect_uri)
+    port = parsed_uri.port
+    if port is None:
+        if parsed_uri.scheme == "https":
+            return 443
+        return 80
+    return port
 
 
 class CallbackHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
The application would crash with a `TypeError` if the redirect URI in the `google_oauth_client.json` file did not specify a port.

This commit fixes the issue by providing a default port (80 for http, 443 for https) if the port is not specified in the redirect URI. This ensures that the callback server can start correctly in all cases.