### PR TITLE
Handle local OAuth ports

### DIFF
--- a/qt_worklog/ui/login_window.py
+++ b/qt_worklog/ui/login_window.py
@@ -29,13 +29,13 @@ class LoginWindow(QWidget):
     @Slot()
     def login(self):
         self.callback_server.start()
-        self.code_verifier = google_auth.open_browser_for_login()
+        self.code_verifier = google_auth.open_browser_for_login(self.callback_server.port)
 
     @Slot(str)
     def handle_auth_code(self, code):
         self.callback_server.stop()
         try:
-            token_data = google_auth.exchange_code_for_token(code, self.code_verifier)
+            token_data = google_auth.exchange_code_for_token(code, self.code_verifier, self.callback_server.port)
             id_token = token_data["id_token"]
             api_client.authenticate_user(id_token)
             credentials.store_credentials(token_data)


### PR DESCRIPTION
## Summary
- propagate callback port when building OAuth URLs
- support dynamic port in authorization and token exchange
- use callback server's port in login window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879bf05cc20832193859a3967ec30e8