### PR TITLE
Fix TokenManager retrieval and login window parameter

### DIFF
--- a/qt_worklog/services/auth/token_manager.py
+++ b/qt_worklog/services/auth/token_manager.py
@@ -13,6 +13,17 @@ class TokenManager(QObject):
         self.timer.timeout.connect(self.refresh_token)
         self.timer.start(55 * 60 * 1000)  # 55 minutes
 
+    def get_token(self) -> str | None:
+        """Return the current ID token if available."""
+        creds = credentials.get_credentials()
+        if creds:
+            return creds.get("id_token")
+        return None
+
+    def clear_token(self) -> None:
+        """Remove any stored credentials."""
+        credentials.delete_credentials()
+
     def refresh_token(self):
         creds = credentials.get_credentials()
         if not creds:

--- a/qt_worklog/ui/login_window.py
+++ b/qt_worklog/ui/login_window.py
@@ -12,8 +12,10 @@ from ..services.auth import credentials
 
 class LoginWindow(QWidget):
     login_successful = Signal()
-    def __init__(self):
+
+    def __init__(self, token_manager=None):
         super().__init__()
+        self.token_manager = token_manager
 
         self.setWindowTitle("Login to Worklog")
         self.setFixedSize(300, 200)


### PR DESCRIPTION
## Summary
- implement `get_token` and `clear_token` in `TokenManager`
- allow passing a token manager to `LoginWindow`

## Testing
- `poetry install`
- `pytest -q`
- `poetry run qt-worklog` *(fails: Could not load the Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_6879c6e78ff48321830fe0e993c6645c