### PR TITLE
Stop tracking worklog.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__/
+worklog.log


### PR DESCRIPTION
## Summary
- update `.gitignore` so `worklog.log` isn't tracked
- remove `worklog.log` from the repo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0aec571c83219f490e423428ad57